### PR TITLE
Make sure two instances don't run under same root

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,15 @@ gkeep_update_config  "[Google email]" "[Google app password]" "[Notes root direc
 ```
 
 _For more information about the config options check `.config.example.json`_
+_Optionally you can provide `GKEEP_CONFIG_PATH` env variable for custom located config file_
 
 Run the server:
 
 ```shell
 gkeep_sync
 ```
+
+_Optionally you can provide `GKEEP_CONFIG_PATH` env variable for custom located config file_
 
 ## Repo setup
 

--- a/gkeep_sync/generate_config.py
+++ b/gkeep_sync/generate_config.py
@@ -1,8 +1,8 @@
 import json
 import sys
-from os import path
+from os import path, mkdir
 
-from .utils import DEFAULT_CONFIG_PATH
+from .utils import DEFAULT_CONFIG_PATH, CONFIG_FOLDER_PATH
 
 import gkeepapi
 
@@ -17,6 +17,9 @@ def generate_config():
         "password": sys.argv[2],
         "notes_root": sys.argv[3]
     }
+
+    if not path.exists(CONFIG_FOLDER_PATH):
+        mkdir(CONFIG_FOLDER_PATH, 0o700)  # Grant access to the user only!
 
     if not path.exists(DEFAULT_CONFIG_PATH):
         open(DEFAULT_CONFIG_PATH, 'x').close()

--- a/gkeep_sync/generate_config.py
+++ b/gkeep_sync/generate_config.py
@@ -1,6 +1,6 @@
 import json
 import sys
-from os import path, mkdir
+from os import path, mkdir, environ
 
 from .utils import DEFAULT_CONFIG_PATH, CONFIG_FOLDER_PATH
 
@@ -24,14 +24,16 @@ def generate_config():
     if not path.exists(DEFAULT_CONFIG_PATH):
         open(DEFAULT_CONFIG_PATH, 'x').close()
 
+    config_path = environ.get('GKEEP_CONFIG_PATH', DEFAULT_CONFIG_PATH)
+
     keep = gkeepapi.Keep()
     keep.login(config['email'], config['password'])
 
     config['token'] = keep.getMasterToken()
 
-    json.dump(config, open(DEFAULT_CONFIG_PATH, 'w'), indent=2)
+    json.dump(config, open(config_path, 'w'), indent=2)
 
-    print(f"You can find the config on: {DEFAULT_CONFIG_PATH}")
+    print(f"You can find the config on: {config_path}")
 
 
 if __name__ == "__main__":

--- a/gkeep_sync/sync_api.py
+++ b/gkeep_sync/sync_api.py
@@ -5,7 +5,7 @@ import requests
 
 import gkeepapi
 
-from .utils import benchmark, traverse_files, DEFAULT_CONFIG_PATH, DUMPED_STATE_PATH
+from .utils import benchmark, traverse_files, DUMPED_STATE_PATH
 
 
 SYNC_LABEL = 'autosync'
@@ -14,9 +14,8 @@ FILE_EXTENSION = 'md'
 
 class SyncAPI:
     @staticmethod
-    def login():
+    def login(config):
         keep = gkeepapi.Keep()
-        config = json.load(open(DEFAULT_CONFIG_PATH))
 
         if not os.path.exists(DUMPED_STATE_PATH):
             keep.resume(config['email'], config['token'])
@@ -33,7 +32,7 @@ class SyncAPI:
     def __init__(self, keep, config):
         self.keep = keep
         self.sync_label = keep.findLabel(SYNC_LABEL)
-        self.notes_root = os.path.expanduser(config['notes_root'])
+        self.notes_root = config['notes_root__absolute']
 
     @benchmark
     def upsert_note(self, note_path):

--- a/gkeep_sync/sync_server.py
+++ b/gkeep_sync/sync_server.py
@@ -34,7 +34,7 @@ def start_server():
 
     config = _build_config()
 
-    wardan_for_duplicate_servers(config)
+    guard_for_duplicate_servers(config)
 
     sync_api = SyncAPI.login(config)
     sync_api.upload_new_notes()
@@ -54,7 +54,7 @@ def start_server():
     observer.join()
 
 
-def wardan_for_duplicate_servers(config):
+def guard_for_duplicate_servers(config):
     notes_root_id = hashlib.md5(config['notes_root__absolute'].encode('utf-8')).hexdigest()
     lock_file_path = os.path.join(CONFIG_FOLDER_PATH, f".lock-{notes_root_id}")
 

--- a/gkeep_sync/sync_server.py
+++ b/gkeep_sync/sync_server.py
@@ -1,9 +1,16 @@
 import time
 import logging
+import json
+import hashlib
+import os
+import atexit
+
+
 from watchdog.observers import Observer
 from watchdog.events import LoggingEventHandler
 
 from .sync_api import SyncAPI
+from .utils import CONFIG_FOLDER_PATH, DEFAULT_CONFIG_PATH
 
 
 SYNC_DOWN_INTERVAL = 60  # seconds
@@ -25,11 +32,15 @@ def start_server():
                         format='%(asctime)s - %(message)s',
                         datefmt='%Y-%m-%d %H:%M:%S')
 
-    sync_api = SyncAPI.login()
+    config = _build_config()
+
+    wardan_for_duplicate_servers(config)
+
+    sync_api = SyncAPI.login(config)
     sync_api.upload_new_notes()
 
     observer = Observer()
-    observer.schedule(EventHandler(sync_api), sync_api.notes_root, recursive=True)
+    observer.schedule(EventHandler(sync_api), config['notes_root__absolute'], recursive=True)
     observer.start()
 
     try:
@@ -41,6 +52,29 @@ def start_server():
         observer.stop()
 
     observer.join()
+
+
+def wardan_for_duplicate_servers(config):
+    notes_root_id = hashlib.md5(config['notes_root__absolute'].encode('utf-8')).hexdigest()
+    lock_file_path = os.path.join(CONFIG_FOLDER_PATH, f".lock-{notes_root_id}")
+
+    if os.path.exists(lock_file_path):
+        print(f"""
+        A GKeep server is already running for notes root \"{config['notes_root__absolute']}\"
+        """)
+
+        # TODO: Find a more suitable status
+        exit(126)
+    else:
+        atexit.register(lambda: os.remove(lock_file_path))
+        open(lock_file_path, 'x').close()
+
+
+def _build_config():
+    config = json.load(open(DEFAULT_CONFIG_PATH))
+    config['notes_root__absolute'] = os.path.expanduser(config['notes_root'])
+
+    return config
 
 
 if __name__ == "__main__":

--- a/gkeep_sync/sync_server.py
+++ b/gkeep_sync/sync_server.py
@@ -5,7 +5,6 @@ import hashlib
 import os
 import atexit
 
-
 from watchdog.observers import Observer
 from watchdog.events import LoggingEventHandler
 
@@ -32,7 +31,7 @@ def start_server():
                         format='%(asctime)s - %(message)s',
                         datefmt='%Y-%m-%d %H:%M:%S')
 
-    config = _build_config()
+    config = build_config()
 
     guard_for_duplicate_servers(config)
 
@@ -70,8 +69,9 @@ def guard_for_duplicate_servers(config):
         open(lock_file_path, 'x').close()
 
 
-def _build_config():
-    config = json.load(open(DEFAULT_CONFIG_PATH))
+def build_config():
+    config_path = os.environ.get('GKEEP_CONFIG_PATH', DEFAULT_CONFIG_PATH)
+    config = json.load(open(config_path))
     config['notes_root__absolute'] = os.path.expanduser(config['notes_root'])
 
     return config

--- a/gkeep_sync/utils.py
+++ b/gkeep_sync/utils.py
@@ -2,9 +2,9 @@ from os import listdir
 from os.path import isfile, join, expanduser
 import time
 
-
-DEFAULT_CONFIG_PATH = join(expanduser("~"), ".gkeep-config.json")
-DUMPED_STATE_PATH = join(expanduser("~"), ".gkeep-state.json")
+CONFIG_FOLDER_PATH = join(expanduser("~"), ".gkeep-sync")
+DEFAULT_CONFIG_PATH = join(CONFIG_FOLDER_PATH, "config.json")
+DUMPED_STATE_PATH = join(CONFIG_FOLDER_PATH, "state.json")
 
 
 def traverse_files(path):

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name='gkeep-sync',
-    version='0.0.1-beta',
+    version='0.0.1',
     author='Kamen Kanev',
     author_email='kamen.e.kanev@gmail.com',
     license='MIT',
@@ -20,9 +20,8 @@ setuptools.setup(
         'watchdog',
         'gkeepapi'
     ],
-    download_url='https://github.com/kanevk/gkeep-files-sync/archive/0.0.1-beta.tar.gz',
+    download_url='https://github.com/kanevk/gkeep-files-sync/archive/0.0.1.tar.gz',
     classifiers=[
-        'Development Status :: 3 - Alpha',
         'Programming Language :: Python :: 3',
         'License :: OSI Approved :: MIT License',
         'Operating System :: Unix',


### PR DESCRIPTION
## Background

The `gkeep-sync` server works over local notes' root directory. The user can run multiple servers over different root directories, but running two servers against a single root is an error prompt.

Another reason to stop this kind of usage is that the package will be used as Backend for VScode extension and the code exit code `126`will be a simplistic way to communicate that the server is already up.

## Aim
 - Move the Gkeep system files under `~/.gkeep` folder
 - warden against two instances run over single notes root
 - exit with code(126) that can be used as a status code for the program running the server